### PR TITLE
[mics] Don't print any visible output when executing macro

### DIFF
--- a/src/main/resources/Macros/AddExcelExportToLivetableMacro.xml
+++ b/src/main/resources/Macros/AddExcelExportToLivetableMacro.xml
@@ -408,7 +408,6 @@ addExportToExcelFunction();</code>
 #set($discard = $xwiki.jsx.use("Macros.AddExcelExportToLivetableMacro"))
 #set($discard = $xwiki.ssx.use("Macros.AddExcelExportToLivetableMacro"))
 #set($discard = $services.localization.use('document', 'Macros.AddExcelExportToLivetableMacroTranslations'))
-$discard
 {{html clean="false"}}
 
 &lt;script language="javascript"&gt;


### PR DESCRIPTION
When using macro, unwanted true/false string is printed on the page
